### PR TITLE
Update binding.gyp to get fixup debug information

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -19,7 +19,8 @@
         "VCLinkerTool": {
           "EntryPointSymbol": "DllMain",       # /ENTRY:DllMain (see notes in main.cc)
           "IgnoreAllDefaultLibraries": "true", # /NODEFAULTLIB (see notes in main.cc)
-          "ImageHasSafeExceptionHandlers": "false"
+          "ImageHasSafeExceptionHandlers": "false",
+          "Profile": "true"
         }
       },
       # Re-enable these warnings that are disabled by default


### PR DESCRIPTION
Update binding.gyp to get fixup debug information in the typescript-etw.node pdb.